### PR TITLE
Count title words

### DIFF
--- a/back-end/src/fetcher.py
+++ b/back-end/src/fetcher.py
@@ -2,7 +2,7 @@ import requests
 from bs4 import BeautifulSoup
 
 class PageFetcher:
-    def __init__(self, url):
+    def __init__(self, url:str):
         self.url = url
 
     def fetch(self) -> BeautifulSoup:

--- a/back-end/src/main.py
+++ b/back-end/src/main.py
@@ -1,15 +1,19 @@
 from constants import Constants
 from fetcher import PageFetcher
 from parser import EntryParser
+from utils import count_words
 
-def run():
+def run() -> None:
     fetcher = PageFetcher(Constants.NEWS_PAGE_URL)
     page_content = fetcher.fetch()
 
     parser = EntryParser(Constants.NUMBER_OF_NEWS, page_content)
-    parsed_page = parser.parse_news()
+    parsed_news = parser.parse_news()
 
-    print(parsed_page)
+    for entry in parsed_news:
+        news_title = getattr(entry, 'title', "")
+        word_count = count_words(news_title)
+        print(f"Title: {news_title}, Word Count: {word_count}")
 
 if __name__ == "__main__":
     run()

--- a/back-end/src/utils.py
+++ b/back-end/src/utils.py
@@ -1,0 +1,5 @@
+import re
+
+def count_words(title:str) -> int:
+    words = re.findall(r'\b\w+\b', title)
+    return len(words)


### PR DESCRIPTION
### Background
We need to filter the obtained news by number of comments if the title has more than 5 words and by number of pints if the title has less than five words. To do it so, we need to count the title's words somehow.

### Changes
- Add a return type for fetcher function
- Add a function that counts the number of words in a news title

### Result
A word count function was created. The function will only take entire words and won't take special characters like commas into account.