### PR TITLE
Add sorters to filter news by commentaries and points

### DIFF
--- a/back-end/src/main.py
+++ b/back-end/src/main.py
@@ -1,7 +1,7 @@
 from constants import Constants
 from fetcher import PageFetcher
 from parser import EntryParser
-from utils import count_words
+from sorter import Sorter
 
 def run() -> None:
     fetcher = PageFetcher(Constants.NEWS_PAGE_URL)
@@ -10,10 +10,10 @@ def run() -> None:
     parser = EntryParser(Constants.NUMBER_OF_NEWS, page_content)
     parsed_news = parser.parse_news()
 
-    for entry in parsed_news:
-        news_title = getattr(entry, 'title', "")
-        word_count = count_words(news_title)
-        print(f"Title: {news_title}, Word Count: {word_count}")
+    sorter = Sorter(parsed_news)
+
+    news_by_comments = sorter.sort_by_comments()
+    news_by_points = sorter.sort_by_points()
 
 if __name__ == "__main__":
     run()

--- a/back-end/src/sorter.py
+++ b/back-end/src/sorter.py
@@ -1,0 +1,21 @@
+from models import NewsItem
+from utils import count_words
+from constants import Constants
+
+class Sorter:
+    def __init__(self, data: list[NewsItem]):
+        self.data = data
+
+    def sort_by_comments(self) -> list[NewsItem]:
+        filtered_news = [
+            entry for entry in self.data
+            if count_words(getattr(entry, 'title', "")) > Constants.LIMIT_FOR_WORDS_IN_TITLE
+        ]
+        return sorted(filtered_news, key=lambda x: x.number_of_comments, reverse=True)
+
+    def sort_by_points(self) -> list[NewsItem]:
+        filtered_news = [
+            entry for entry in self.data
+            if count_words(getattr(entry, 'title', "")) <= Constants.LIMIT_FOR_WORDS_IN_TITLE
+        ]
+        return sorted(filtered_news, key=lambda x: x.points, reverse=True)


### PR DESCRIPTION
### Background
Now that we have the news inside an object, we can manipulate them. The requirement is to filter the obtained news by number of comments if the news title has more than 5 words and by number of points if the news title has less than five words.

### Changes
- Add sorters to filter news by commentaries and points

### Result
Two functions were created to filter the news as requested. The results can now be sent to a front-end app by exposing the corresponding endpoints.