### PR TITLE
Show link to the corresponding news for each entry

### DIFF
--- a/back-end/app/parser.py
+++ b/back-end/app/parser.py
@@ -13,7 +13,7 @@ class EntryParser:
 
             for row in table:
                 number = row.select_one('.rank').get_text().strip('.')
-                title = row.select_one('.titleline > a').get_text()
+                title = row.select_one('.titleline').get_text()
                 subtext = row.find_next_sibling('tr').select_one('.subtext')
                 points_element = subtext.select_one('.score') if subtext else None
                 points = points_element.get_text().split()[0] if points_element else '0'


### PR DESCRIPTION
### Background
The sorted news were shown in the card component but the link to read the complete news was not there.

### Changes
- Edit filter from the parser to get the link to the news

### Result
For each news shown in the card, its corresponding link will also be shown so that the user can access to the complete news