### PR TITLE
Add commands to makefile to install dependencies and run the apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,18 @@
+setup-api:
+	cd ./back-end && \
+	python3 -m venv venv && \
+	. venv/bin/activate && \
+	pip install -r requirements.txt
+
+setup-ui:
+	cd ./front-end && \
+	npm install
+
 run-api:
 	cd ./back-end && \
 	. venv/bin/activate && \
 	python3 -m app.main
+
+run-ui:
+	cd ./front-end && \
+	npm run dev


### PR DESCRIPTION
### Background
The app is working but the user may find uncomfortable running all the commands to install dependencies, create virtual environments and move between folders.

### Changes
- Add commands to makefile to install dependencies and run the apps

### Result
Now the user is going to run only two commands to run the front-end and two commands to run the back-end.